### PR TITLE
Updates route protection for edit tea info

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { Role } from "./generated/prisma/enums";
 
-const PROTECTED_ROUTES = ["/profile"];
-const EXECUTEAVE_ROUTES = ["/edit-tea-info"];
-const ADMIN_ROUTES = ["/admin-dashboard", "/users"];
+const PROTECTED_ROUTES: Array<string> = ["/profile", "/edit-tea-info"];
+const EXECUTEAVE_ROUTES: Array<string> = [];
+const ADMIN_ROUTES: Array<string> = ["/admin-dashboard", "/users"];
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
Updates the route protection for `/edit-tea-info` to require authentication instead of an executive role.

This change aligns with the intended access control requirements for this route, ensuring that only authenticated users can access it.